### PR TITLE
Refactor ValidateLogin to be a static method

### DIFF
--- a/coiled-tubing-app/LoginPage.xaml.cs
+++ b/coiled-tubing-app/LoginPage.xaml.cs
@@ -33,7 +33,7 @@ namespace coiled_tubing_app
             }
         }
 
-        private bool ValidateLogin(string username, string password)
+        private static bool ValidateLogin(string username, string password)
         {
             // Contoh validasi sederhana - ganti dengan logika autentikasi yang sebenarnya
             // Misalnya: validasi dengan database, API, atau Active Directory


### PR DESCRIPTION
Changed the `ValidateLogin` method in `LoginPage.xaml.cs` from an instance method to a static method by adding the `static` keyword. The method's functionality for validating username and password remains unchanged.